### PR TITLE
Remove synchronous imports completely

### DIFF
--- a/Tests/StorageApiHeadlessWriterTest.php
+++ b/Tests/StorageApiHeadlessWriterTest.php
@@ -88,7 +88,9 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -118,7 +120,9 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $table = $this->client->getTable("out.c-docker-test.table");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -152,7 +156,9 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -183,7 +189,9 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -223,7 +231,9 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);

--- a/Tests/StorageApiHeadlessWriterTest.php
+++ b/Tests/StorageApiHeadlessWriterTest.php
@@ -90,7 +90,7 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -122,7 +122,7 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $table = $this->client->getTable("out.c-docker-test.table");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -158,7 +158,7 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -191,7 +191,7 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -233,7 +233,7 @@ class StorageApiHeadlessWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);

--- a/Tests/StorageApiSlicedWriterTest.php
+++ b/Tests/StorageApiSlicedWriterTest.php
@@ -98,7 +98,10 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(2, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+        $this->client->waitForJob($jobIds[1]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -132,7 +135,9 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $table = $this->client->getTable("out.c-docker-test.table");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -167,7 +172,9 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $table = $this->client->getTable("out.c-docker-test.table");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -197,7 +204,9 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $table = $this->client->getTable("out.c-docker-test.table");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -232,7 +241,9 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $table = $this->client->getTable("out.c-docker-test.table");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -298,7 +309,9 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -337,7 +350,9 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -379,7 +394,10 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(2, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+        $this->client->waitForJob($jobIds[1]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(2, $tables);
@@ -428,7 +446,10 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(2, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+        $this->client->waitForJob($jobIds[1]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);

--- a/Tests/StorageApiSlicedWriterTest.php
+++ b/Tests/StorageApiSlicedWriterTest.php
@@ -100,7 +100,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -136,7 +136,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $table = $this->client->getTable("out.c-docker-test.table");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -173,7 +173,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $table = $this->client->getTable("out.c-docker-test.table16");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -205,7 +205,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $table = $this->client->getTable("out.c-docker-test.table15");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -242,7 +242,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $table = $this->client->getTable("out.c-docker-test.table17");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
@@ -310,7 +310,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -351,7 +351,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -395,8 +395,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(2, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
-        $this->client->waitForJob($jobIds[1]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(2, $tables);
@@ -447,7 +446,7 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);

--- a/Tests/StorageApiSlicedWriterTest.php
+++ b/Tests/StorageApiSlicedWriterTest.php
@@ -99,9 +99,8 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
-        $this->assertCount(2, $jobIds);
+        $this->assertCount(1, $jobIds);
         $this->client->waitForJob($jobIds[0]);
-        $this->client->waitForJob($jobIds[1]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -158,15 +157,15 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $fileName = $this->tmp->getTmpFolder() . uniqid('csv-');
         file_put_contents($fileName, "\"Id\",\"Name\"\n\"ab\",\"cd\"\n");
         $csv = new CsvFile($fileName);
-        $this->client->createTable('out.c-docker-test', 'table', $csv);
+        $this->client->createTable('out.c-docker-test', 'table16', $csv);
 
         $root = $this->tmp->getTmpFolder();
-        mkdir($root . "/upload/table");
-        file_put_contents($root . "/upload/table/part1", "");
+        mkdir($root . "/upload/table16");
+        file_put_contents($root . "/upload/table16/part1", "");
         $configs = [
             [
-                "source" => "table",
-                "destination" => "out.c-docker-test.table",
+                "source" => "table16",
+                "destination" => "out.c-docker-test.table16",
                 "columns" => ["Id","Name"]
             ]
         ];
@@ -176,12 +175,12 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $jobIds);
         $this->client->waitForJob($jobIds[0]);
 
-        $table = $this->client->getTable("out.c-docker-test.table");
+        $table = $this->client->getTable("out.c-docker-test.table16");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
 
         $exporter = new TableExporter($this->client);
         $downloadedFile = $this->tmp->getTmpFolder() . DIRECTORY_SEPARATOR . "download.csv";
-        $exporter->exportTable('out.c-docker-test.table', $downloadedFile, []);
+        $exporter->exportTable('out.c-docker-test.table16', $downloadedFile, []);
         $table = $this->client->parseCsv(file_get_contents($downloadedFile));
         $this->assertCount(0, $table);
     }
@@ -193,12 +192,12 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
     {
         $this->initBucket($backendType);
         $root = $this->tmp->getTmpFolder();
-        mkdir($root . "/upload/table");
+        mkdir($root . "/upload/table15");
 
         $configs = [
             [
-                "source" => "table",
-                "destination" => "out.c-docker-test.table",
+                "source" => "table15",
+                "destination" => "out.c-docker-test.table15",
                 "columns" => ["Id","Name"]
             ]
         ];
@@ -208,12 +207,12 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $jobIds);
         $this->client->waitForJob($jobIds[0]);
 
-        $table = $this->client->getTable("out.c-docker-test.table");
+        $table = $this->client->getTable("out.c-docker-test.table15");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
 
         $exporter = new TableExporter($this->client);
         $downloadedFile = $this->tmp->getTmpFolder() . DIRECTORY_SEPARATOR . "download.csv";
-        $exporter->exportTable('out.c-docker-test.table', $downloadedFile, []);
+        $exporter->exportTable('out.c-docker-test.table15', $downloadedFile, []);
         $table = $this->client->parseCsv(file_get_contents($downloadedFile));
         $this->assertCount(0, $table);
     }
@@ -227,15 +226,15 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $fileName = $this->tmp->getTmpFolder() . uniqid('csv-');
         file_put_contents($fileName, "\"Id\",\"Name\"\n\"ab\",\"cd\"\n");
         $csv = new CsvFile($fileName);
-        $this->client->createTable('out.c-docker-test', 'table', $csv);
+        $this->client->createTable('out.c-docker-test', 'table17', $csv);
 
         $root = $this->tmp->getTmpFolder();
-        mkdir($root . "/upload/table");
+        mkdir($root . "/upload/table17");
 
         $configs = [
             [
-                "source" => "table",
-                "destination" => "out.c-docker-test.table",
+                "source" => "table17",
+                "destination" => "out.c-docker-test.table17",
                 "columns" => ["Id","Name"]
             ]
         ];
@@ -245,12 +244,12 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $jobIds);
         $this->client->waitForJob($jobIds[0]);
 
-        $table = $this->client->getTable("out.c-docker-test.table");
+        $table = $this->client->getTable("out.c-docker-test.table17");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
 
         $exporter = new TableExporter($this->client);
         $downloadedFile = $this->tmp->getTmpFolder() . DIRECTORY_SEPARATOR . "download.csv";
-        $exporter->exportTable('out.c-docker-test.table', $downloadedFile, []);
+        $exporter->exportTable('out.c-docker-test.table17', $downloadedFile, []);
         $table = $this->client->parseCsv(file_get_contents($downloadedFile));
         $this->assertCount(0, $table);
     }
@@ -430,16 +429,16 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
     {
         $this->initBucket($backendType);
         $root = $this->tmp->getTmpFolder();
-        mkdir($root . "/upload/table.csv");
-        file_put_contents($root . "/upload/table.csv/part1", "\"test\",\"test\"\n");
-        file_put_contents($root . "/upload/table.csv/part2", "\"aabb\",\"ccdd\"\n");
-        exec("gzip " . $root . "/upload/table.csv/part1");
-        exec("gzip " . $root . "/upload/table.csv/part2");
+        mkdir($root . "/upload/table18.csv");
+        file_put_contents($root . "/upload/table18.csv/part1", "\"test\",\"test\"\n");
+        file_put_contents($root . "/upload/table18.csv/part2", "\"aabb\",\"ccdd\"\n");
+        exec("gzip " . $root . "/upload/table18.csv/part1");
+        exec("gzip " . $root . "/upload/table18.csv/part2");
 
         $configs = [
             [
-                "source" => "table.csv",
-                "destination" => "out.c-docker-test.table",
+                "source" => "table18.csv",
+                "destination" => "out.c-docker-test.table18",
                 "columns" => ["Id","Name"]
             ]
         ];
@@ -447,18 +446,17 @@ class StorageApiSlicedWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
-        $this->assertCount(2, $jobIds);
+        $this->assertCount(1, $jobIds);
         $this->client->waitForJob($jobIds[0]);
-        $this->client->waitForJob($jobIds[1]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
-        $table = $this->client->getTable("out.c-docker-test.table");
+        $table = $this->client->getTable("out.c-docker-test.table18");
         $this->assertEquals(["Id", "Name"], $table["columns"]);
 
         $exporter = new TableExporter($this->client);
         $downloadedFile = $this->tmp->getTmpFolder() . DIRECTORY_SEPARATOR . "download.csv";
-        $exporter->exportTable('out.c-docker-test.table', $downloadedFile, []);
+        $exporter->exportTable('out.c-docker-test.table18', $downloadedFile, []);
         $table = $this->client->parseCsv(file_get_contents($downloadedFile));
         $this->assertCount(2, $table);
         $this->assertContains(["Id" => "test", "Name" => "test"], $table);

--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -77,13 +77,13 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
     public function testMetadataWritingTest()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
+        file_put_contents($root . "/upload/table55.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
 
         $config = [
             "mapping" => [
                 [
-                    "source" => "table1.csv",
-                    "destination" => "in.c-docker-test.table1",
+                    "source" => "table55.csv",
+                    "destination" => "in.c-docker-test.table55",
                     "metadata" => [
                         [
                             "key" => "table.key.one",
@@ -125,10 +125,12 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", $config, $systemMetadata);
+        $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
         $metadataApi = new Metadata($this->client);
 
-        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table1');
+        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table55');
         $expectedTableMetadata = [
             'system' => [
                 'KBC.createdBy.component.id' => 'testComponent',
@@ -141,7 +143,7 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         ];
         self::assertEquals($expectedTableMetadata, $this->getMetadataValues($tableMetadata));
 
-        $idColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test.table1.Id');
+        $idColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test.table55.Id');
         $expectedColumnMetadata = [
             'testComponent' => [
                 'column.key.one' => 'column value one id',
@@ -151,8 +153,11 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         self::assertEquals($expectedColumnMetadata, $this->getMetadataValues($idColMetadata));
 
         // check metadata update
-        $writer->uploadTables($root . "/upload", $config, $systemMetadata);
-        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table1');
+        $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+
+        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table55');
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.configuration.id'] = 'metadata-write-test';
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.component.id'] = 'testComponent';
         self::assertEquals($expectedTableMetadata, $this->getMetadataValues($tableMetadata));
@@ -161,13 +166,13 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
     public function testConfigRowMetadataWritingTest()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
+        file_put_contents($root . "/upload/table66.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
 
         $config = [
             "mapping" => [
                 [
-                    "source" => "table1.csv",
-                    "destination" => "in.c-docker-test.table1",
+                    "source" => "table66.csv",
+                    "destination" => "in.c-docker-test.table66",
                     "metadata" => [
                         [
                             "key" => "table.key.one",
@@ -210,10 +215,13 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", $config, $systemMetadata);
+        $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+
         $metadataApi = new Metadata($this->client);
 
-        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table1');
+        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table66');
         $expectedTableMetadata = [
             'system' => [
                 'KBC.createdBy.component.id' => 'testComponent',
@@ -227,7 +235,7 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         ];
         self::assertEquals($expectedTableMetadata, $this->getMetadataValues($tableMetadata));
 
-        $idColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test.table1.Id');
+        $idColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test.table66.Id');
         $expectedColumnMetadata = [
             'testComponent' => [
                 'column.key.one' => 'column value one id',
@@ -237,8 +245,11 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         self::assertEquals($expectedColumnMetadata, $this->getMetadataValues($idColMetadata));
 
         // check metadata update
-        $writer->uploadTables($root . "/upload", $config, $systemMetadata);
-        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table1');
+        $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+
+        $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table66');
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.configurationRow.id'] = 'row-1';
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.configuration.id'] = 'metadata-write-test';
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.component.id'] = 'testComponent';

--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -127,7 +127,7 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
         $metadataApi = new Metadata($this->client);
 
         $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table55');
@@ -155,7 +155,7 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         // check metadata update
         $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table55');
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.configuration.id'] = 'metadata-write-test';
@@ -217,7 +217,7 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $metadataApi = new Metadata($this->client);
 
@@ -247,7 +247,7 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         // check metadata update
         $jobIds = $writer->uploadTables($root . "/upload", $config, $systemMetadata);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tableMetadata = $metadataApi->listTableMetadata('in.c-docker-test.table66');
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.configurationRow.id'] = 'row-1';

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -1191,7 +1191,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->handleAsyncTasks($jobIds);
+        $job = $this->client->waitForJob($jobIds[0]);
         $this->assertEquals('error', $job['status']);
         $this->assertContains(
             'Some columns are missing in the csv file. Missing columns: id,name.',

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -497,7 +497,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         );
         file_put_contents(
             $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-default-test.table3c.csv.manifest",
-            "{\"destination\": \"out.c-docker-default-test.table3\",\"delimiter\": \"\\t\",\"enclosure\": \"'\"}"
+            "{\"destination\": \"out.c-docker-default-test.table3c\",\"delimiter\": \"\\t\",\"enclosure\": \"'\"}"
         );
 
         $writer = new Writer($this->client, new NullLogger());
@@ -1126,7 +1126,6 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($handler->hasWarningThatContains("Output mapping does not match destination table"));
         $tableInfo = $this->client->getTable("out.c-docker-test.table12");
         $this->assertEquals([], $tableInfo["primaryKey"]);
-
     }
 
     public function testWriteTableOutputMappingWithEmptyStringPkInManifest()
@@ -1142,7 +1141,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             [
                 "mapping" => [
                     [
-                        "source" => "table9.csv",
+                        "source" => "table11.csv",
                         "destination" => "out.c-docker-test.table11",
                         "primary_key" => []
                     ]
@@ -1166,9 +1165,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
                 "Output mapping does not match destination table: primary key '' does not match '' in 'out.c-docker-test.table9'."
             )
         );
-        $tableInfo = $this->client->getTable("out.c-docker-test.table9");
+        $tableInfo = $this->client->getTable("out.c-docker-test.table11");
         $this->assertEquals([], $tableInfo["primaryKey"]);
-
     }
 
     public function testWriteTableColumnsOverwrite()

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -593,14 +593,18 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
 
         $tables = $this->client->listTables("out.c-docker-test");
+        $this->assertCount(1, $jobIds);
         $this->assertCount(1, $tables);
 
         $this->assertEquals('out.c-docker-test.table4', $tables[0]["id"]);
         $tableInfo = $this->client->getTable('out.c-docker-test.table4');
         $this->assertEquals(["Id", "Name"], $tableInfo["columns"]);
+
+        // let the test fully finish before starting another one
+        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableBareWithoutSuffix()
@@ -610,14 +614,18 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
 
         $tables = $this->client->listTables("out.c-docker-test");
+        $this->assertCount(1, $jobIds);
         $this->assertCount(1, $tables);
 
         $this->assertEquals('out.c-docker-test.table4', $tables[0]["id"]);
         $tableInfo = $this->client->getTable('out.c-docker-test.table4');
         $this->assertEquals(["Id", "Name"], $tableInfo["columns"]);
+
+        // let the test fully finish before starting another one
+        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableIncrementalWithDeleteDefault()
@@ -889,7 +897,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         file_put_contents($root . "/upload/table9.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n");
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables(
+        $jobIds = $writer->uploadTables(
             $root . "/upload",
             [
                 "mapping" => [
@@ -902,8 +910,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ],
             ['componentId' => 'foo']
         );
+        $this->assertCount(1, $jobIds);
         $tableInfo = $this->client->getTable("out.c-docker-test.table9");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
+
+        // let the test fully finish before starting another one
+        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableOutputMappingWithPkOverwrite()
@@ -927,7 +939,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         );
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables(
+        $jobIds = $writer->uploadTables(
             $root . "/upload",
             [
                 "mapping" => [
@@ -942,7 +954,11 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         );
         $tableInfo = $this->client->getTable("out.c-docker-test.table9");
 
+        $this->assertCount(1, $jobIds);
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
+
+        // let the test fully finish before starting another one
+        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableOutputMappingWithPkMismatch()

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -325,6 +325,9 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(2, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+        $this->client->waitForJob($jobIds[1]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(2, $tables);
@@ -349,15 +352,18 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         // And again
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
         $this->assertEquals('out.c-docker-test.table1', $tables[0]["id"]);
-        $this->assertCount(1, $jobIds);
         $this->assertNotEmpty($jobIds[0]);
     }
 
@@ -375,7 +381,9 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -425,7 +433,9 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -437,21 +447,23 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     {
         $root = $this->tmp->getTmpFolder();
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3.csv",
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3a.csv",
             "\"Id\",\"Name\"\n\"test\",\"test\"\n"
         );
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3.csv.manifest",
-            "{\"destination\": \"out.c-docker-test.table3\",\"primary_key\": [\"Id\",\"Name\"]}"
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3a.csv.manifest",
+            "{\"destination\": \"out.c-docker-test.table3a\",\"primary_key\": [\"Id\",\"Name\"]}"
         );
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
-        $this->assertEquals('out.c-docker-test.table3', $tables[0]["id"]);
+        $this->assertEquals('out.c-docker-test.table3a', $tables[0]["id"]);
         $this->assertEquals(["Id", "Name"], $tables[0]["primaryKey"]);
     }
 
@@ -459,11 +471,11 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     {
         $root = $this->tmp->getTmpFolder();
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3.csv",
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3b.csv",
             "\"Id\",\"Name\"\n\"test\",\"test\"\n"
         );
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3.csv.manifest",
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-test.table3b.csv.manifest",
             "{\"destination\": \"out.c-docker-test.table3\",\"primary_key\": \"Id\"}"
         );
 
@@ -480,24 +492,26 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     {
         $root = $this->tmp->getTmpFolder();
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-default-test.table3.csv",
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-default-test.table3c.csv",
             "'Id'\t'Name'\n'test'\t'test''s'\n"
         );
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-default-test.table3.csv.manifest",
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-default-test.table3c.csv.manifest",
             "{\"destination\": \"out.c-docker-default-test.table3\",\"delimiter\": \"\\t\",\"enclosure\": \"'\"}"
         );
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-default-test");
         $this->assertCount(1, $tables);
-        $this->assertEquals('out.c-docker-default-test.table3', $tables[0]["id"]);
+        $this->assertEquals('out.c-docker-default-test.table3c', $tables[0]["id"]);
         $exporter = new TableExporter($this->client);
         $downloadedFile = $root . DIRECTORY_SEPARATOR . "download.csv";
-        $exporter->exportTable('out.c-docker-default-test.table3', $downloadedFile, []);
+        $exporter->exportTable('out.c-docker-default-test.table3c', $downloadedFile, []);
         $table = $this->client->parseCsv(file_get_contents($downloadedFile));
         $this->assertEquals(1, count($table));
         $this->assertEquals(2, count($table[0]));
@@ -511,24 +525,26 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     {
         $root = $this->tmp->getTmpFolder();
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-redshift-test.table3.csv",
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-redshift-test.table3d.csv",
             "'Id'\t'Name'\n'test'\t'test''s'\n"
         );
         file_put_contents(
-            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-redshift-test.table3.csv.manifest",
-            "{\"destination\": \"out.c-docker-redshift-test.table3\",\"delimiter\": \"\\t\",\"enclosure\": \"'\"}"
+            $root . DIRECTORY_SEPARATOR . "upload/out.c-docker-redshift-test.table3d.csv.manifest",
+            "{\"destination\": \"out.c-docker-redshift-test.table3d\",\"delimiter\": \"\\t\",\"enclosure\": \"'\"}"
         );
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-redshift-test");
         $this->assertCount(1, $tables);
-        $this->assertEquals('out.c-docker-redshift-test.table3', $tables[0]["id"]);
+        $this->assertEquals('out.c-docker-redshift-test.table3d', $tables[0]["id"]);
         $exporter = new TableExporter($this->client);
         $downloadedFile = $root . DIRECTORY_SEPARATOR . "download.csv";
-        $exporter->exportTable('out.c-docker-redshift-test.table3', $downloadedFile, []);
+        $exporter->exportTable('out.c-docker-redshift-test.table3d', $downloadedFile, []);
         $table = $this->client->parseCsv(file_get_contents($downloadedFile));
         $this->assertEquals(1, count($table));
         $this->assertEquals(2, count($table[0]));
@@ -543,7 +559,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $root = $this->tmp->getTmpFolder();
         file_put_contents(
             $root . DIRECTORY_SEPARATOR . "upload/table.csv.manifest",
-            "{\"destination\": \"out.c-docker-test.table3\",\"primary_key\": [\"Id\", \"Name\"]}"
+            "{\"destination\": \"out.c-docker-test.table3e\",\"primary_key\": [\"Id\", \"Name\"]}"
         );
         $writer = new Writer($this->client, new NullLogger());
         try {
@@ -594,17 +610,15 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
-        $this->assertCount(1, $jobIds);
         $this->assertCount(1, $tables);
 
         $this->assertEquals('out.c-docker-test.table4', $tables[0]["id"]);
         $tableInfo = $this->client->getTable('out.c-docker-test.table4');
         $this->assertEquals(["Id", "Name"], $tableInfo["columns"]);
-
-        // let the test fully finish before starting another one
-        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableBareWithoutSuffix()
@@ -615,17 +629,15 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
-        $this->assertCount(1, $jobIds);
         $this->assertCount(1, $tables);
 
         $this->assertEquals('out.c-docker-test.table4', $tables[0]["id"]);
         $tableInfo = $this->client->getTable('out.c-docker-test.table4');
         $this->assertEquals(["Id", "Name"], $tableInfo["columns"]);
-
-        // let the test fully finish before starting another one
-        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableIncrementalWithDeleteDefault()
@@ -646,10 +658,15 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         // And again, check first incremental table
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+
         $exporter = new TableExporter($this->client);
         $exporter->exportTable("out.c-docker-default-test.table1", $root . DIRECTORY_SEPARATOR . "download.csv", []);
         $table = $this->client->parseCsv(file_get_contents($root . DIRECTORY_SEPARATOR . "download.csv"));
@@ -686,10 +703,15 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         // And again, check first incremental table
-        $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+
         $exporter = new TableExporter($this->client);
         $exporter->exportTable("out.c-docker-redshift-test.table1", $root . DIRECTORY_SEPARATOR . "download.csv", []);
         $table = $this->client->parseCsv(file_get_contents($root . DIRECTORY_SEPARATOR . "download.csv"));
@@ -741,7 +763,10 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ["bucket" => "in.c-docker-test"], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["bucket" => "in.c-docker-test"], ['componentId' => 'foo']);
+        $this->assertCount(2, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+        $this->client->waitForJob($jobIds[1]);
 
         $tables = $this->client->listTables("in.c-docker-test");
         $this->assertCount(2, $tables);
@@ -790,7 +815,9 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables($root . "/upload", ['bucket' => 'out.c-docker-test'], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ['bucket' => 'out.c-docker-test'], ['componentId' => 'foo']);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -812,11 +839,13 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer = new Writer($this->client, new NullLogger());
 
-        $writer->uploadTables(
+        $jobIds = $writer->uploadTables(
             $root . "/upload",
             ["mapping" => $configs, 'bucket' => 'out.c-docker-test'],
             ['componentId' => 'foo']
         );
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -915,11 +944,9 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
         $tableInfo = $this->client->getTable("out.c-docker-test.table16");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
-
-        // let the test fully finish before starting another one
-        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableOutputMappingWithPkOverwrite()
@@ -956,13 +983,11 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ],
             ['componentId' => 'foo']
         );
-        $tableInfo = $this->client->getTable("out.c-docker-test.table15");
-
         $this->assertCount(1, $jobIds);
-        $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
-
-        // let the test fully finish before starting another one
         $this->client->waitForJob($jobIds[0]);
+
+        $tableInfo = $this->client->getTable("out.c-docker-test.table15");
+        $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
     }
 
     public function testWriteTableOutputMappingWithPkMismatch()
@@ -1095,12 +1120,11 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
         $this->assertFalse($handler->hasWarningThatContains("Output mapping does not match destination table"));
         $tableInfo = $this->client->getTable("out.c-docker-test.table12");
         $this->assertEquals([], $tableInfo["primaryKey"]);
 
-        // let the test fully finish before starting another one
-        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableOutputMappingWithEmptyStringPkInManifest()
@@ -1132,6 +1156,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         );
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
         $this->assertFalse(
             $handler->hasWarningThatContains(
                 "Output mapping does not match destination table: primary key '' does not match '' in 'out.c-docker-test.table9'."
@@ -1140,8 +1165,6 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $tableInfo = $this->client->getTable("out.c-docker-test.table9");
         $this->assertEquals([], $tableInfo["primaryKey"]);
 
-        // let the test fully finish before starting another one
-        $this->client->waitForJob($jobIds[0]);
     }
 
     public function testWriteTableColumnsOverwrite()

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -352,7 +352,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $writer = new Writer($this->client, new NullLogger());
-        $jobIds = writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
+        $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
         $this->client->waitForJob($jobIds[0]);
 
@@ -1040,7 +1040,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $root = $this->tmp->getTmpFolder();
         file_put_contents($root . "/upload/table13.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n");
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables(
+        $jobIds = $writer->uploadTables(
             $root . "/upload",
             [
                 "mapping" => [
@@ -1053,6 +1053,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ],
             ['componentId' => 'foo']
         );
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
         $tableInfo = $this->client->getTable("out.c-docker-test.table13");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
 
@@ -1135,7 +1137,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $handler = new TestHandler();
 
         $writer = new Writer($this->client, (new Logger("null"))->pushHandler($handler));
-        $writer->uploadTables(
+        $jobIds = $writer->uploadTables(
             $root . "/upload",
             [
                 "mapping" => [
@@ -1148,6 +1150,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ],
             ['componentId' => 'foo']
         );
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
 
         $writer = new Writer($this->client, (new Logger("null"))->pushHandler($handler));
         file_put_contents(

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -308,17 +308,17 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     public function testWriteTableOutputMapping()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
-        file_put_contents($root . "/upload/table2.csv", "\"Id2\",\"Name2\"\n\"test2\",\"test2\"\n\"aabb2\",\"ccdd2\"\n");
+        file_put_contents($root . "/upload/table1a.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
+        file_put_contents($root . "/upload/table2a.csv", "\"Id2\",\"Name2\"\n\"test2\",\"test2\"\n\"aabb2\",\"ccdd2\"\n");
 
         $configs = [
             [
-                "source" => "table1.csv",
-                "destination" => "out.c-docker-test.table1"
+                "source" => "table1a.csv",
+                "destination" => "out.c-docker-test.table1a"
             ],
             [
-                "source" => "table2.csv",
-                "destination" => "out.c-docker-test.table2"
+                "source" => "table2a.csv",
+                "destination" => "out.c-docker-test.table2a"
             ]
         ];
 
@@ -333,7 +333,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $tables);
         $tableIds = [$tables[0]["id"], $tables[1]["id"]];
         sort($tableIds);
-        $this->assertEquals(['out.c-docker-test.table1', 'out.c-docker-test.table2'], $tableIds);
+        $this->assertEquals(['out.c-docker-test.table1a', 'out.c-docker-test.table2a'], $tableIds);
         $this->assertCount(2, $jobIds);
         $this->assertNotEmpty($jobIds[0]);
         $this->assertNotEmpty($jobIds[1]);
@@ -342,12 +342,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     public function testWriteTableOutputMappingExistingTable()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
+        file_put_contents($root . "/upload/table21.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
 
         $configs = [
             [
-                "source" => "table1.csv",
-                "destination" => "out.c-docker-test.table1"
+                "source" => "table21.csv",
+                "destination" => "out.c-docker-test.table21"
             ]
         ];
 
@@ -363,19 +363,19 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
-        $this->assertEquals('out.c-docker-test.table1', $tables[0]["id"]);
+        $this->assertEquals('out.c-docker-test.table21', $tables[0]["id"]);
         $this->assertNotEmpty($jobIds[0]);
     }
 
     public function testWriteTableOutputMappingWithoutCsv()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
+        file_put_contents($root . "/upload/table31", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
 
         $configs = [
             [
-                "source" => "table1",
-                "destination" => "out.c-docker-test.table1"
+                "source" => "table31",
+                "destination" => "out.c-docker-test.table31"
             ]
         ];
 
@@ -387,18 +387,18 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
-        $this->assertEquals('out.c-docker-test.table1', $tables[0]["id"]);
+        $this->assertEquals('out.c-docker-test.table31', $tables[0]["id"]);
     }
 
     public function testWriteTableOutputMappingEmptyFile()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1", "");
+        file_put_contents($root . "/upload/table41", "");
 
         $configs = [
             [
-                "source" => "table1",
-                "destination" => "out.c-docker-test.table1"
+                "source" => "table41",
+                "destination" => "out.c-docker-test.table41"
             ]
         ];
 
@@ -576,8 +576,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $configs = [
             [
-                "source" => "table1.csv",
-                "destination" => "out.c-docker-test.table1"
+                "source" => "table81.csv",
+                "destination" => "out.c-docker-test.table81"
             ]
         ];
         $writer = new Writer($this->client, new NullLogger());
@@ -585,7 +585,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
             $this->fail("Missing table file must fail");
         } catch (InvalidOutputException $e) {
-            $this->assertContains("Table source 'table1.csv' not found", $e->getMessage());
+            $this->assertContains("Table source 'table81.csv' not found", $e->getMessage());
         }
     }
 
@@ -643,12 +643,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     public function testWriteTableIncrementalWithDeleteDefault()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
+        file_put_contents($root . "/upload/table51.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
 
         $configs = [
             [
-                "source" => "table1.csv",
-                "destination" => "out.c-docker-default-test.table1",
+                "source" => "table51.csv",
+                "destination" => "out.c-docker-default-test.table51",
                 "delete_where_column" => "Id",
                 "delete_where_values" => ["aabb"],
                 "delete_where_operator" => "eq",
@@ -668,7 +668,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $this->client->waitForJob($jobIds[0]);
 
         $exporter = new TableExporter($this->client);
-        $exporter->exportTable("out.c-docker-default-test.table1", $root . DIRECTORY_SEPARATOR . "download.csv", []);
+        $exporter->exportTable("out.c-docker-default-test.table51", $root . DIRECTORY_SEPARATOR . "download.csv", []);
         $table = $this->client->parseCsv(file_get_contents($root . DIRECTORY_SEPARATOR . "download.csv"));
         usort($table, function ($a, $b) {
             return strcasecmp($a['Id'], $b['Id']);
@@ -688,12 +688,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     public function testWriteTableIncrementalWithDeleteRedshift()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
+        file_put_contents($root . "/upload/table61.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n\"aabb\",\"ccdd\"\n");
 
         $configs = [
             [
-                "source" => "table1.csv",
-                "destination" => "out.c-docker-redshift-test.table1",
+                "source" => "table61.csv",
+                "destination" => "out.c-docker-redshift-test.table61",
                 "delete_where_column" => "Id",
                 "delete_where_values" => ["aabb"],
                 "delete_where_operator" => "eq",
@@ -713,7 +713,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $this->client->waitForJob($jobIds[0]);
 
         $exporter = new TableExporter($this->client);
-        $exporter->exportTable("out.c-docker-redshift-test.table1", $root . DIRECTORY_SEPARATOR . "download.csv", []);
+        $exporter->exportTable("out.c-docker-redshift-test.table61", $root . DIRECTORY_SEPARATOR . "download.csv", []);
         $table = $this->client->parseCsv(file_get_contents($root . DIRECTORY_SEPARATOR . "download.csv"));
         usort($table, function ($a, $b) {
             return strcasecmp($a['Id'], $b['Id']);
@@ -758,8 +758,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
     public function testWriteTableToDefaultBucket()
     {
         $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/table1.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n");
-        file_put_contents($root . "/upload/table2.csv", "\"Id\",\"Name2\"\n\"test2\",\"test2\"\n");
+        file_put_contents($root . "/upload/table71.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n");
+        file_put_contents($root . "/upload/table72.csv", "\"Id\",\"Name2\"\n\"test2\",\"test2\"\n");
 
         $writer = new Writer($this->client, new NullLogger());
 
@@ -771,12 +771,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $tables = $this->client->listTables("in.c-docker-test");
         $this->assertCount(2, $tables);
 
-        $this->assertEquals('in.c-docker-test.table1', $tables[0]["id"]);
-        $tableInfo = $this->client->getTable('in.c-docker-test.table1');
+        $this->assertEquals('in.c-docker-test.table71', $tables[0]["id"]);
+        $tableInfo = $this->client->getTable('in.c-docker-test.table71');
         $this->assertEquals(["Id", "Name"], $tableInfo["columns"]);
 
-        $this->assertEquals('in.c-docker-test.table2', $tables[1]["id"]);
-        $tableInfo = $this->client->getTable('in.c-docker-test.table2');
+        $this->assertEquals('in.c-docker-test.table72', $tables[1]["id"]);
+        $tableInfo = $this->client->getTable('in.c-docker-test.table72');
         $this->assertEquals(["Id", "Name2"], $tableInfo["columns"]);
     }
 
@@ -995,7 +995,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $root = $this->tmp->getTmpFolder();
         file_put_contents($root . "/upload/table14.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n");
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables(
+        $jobIds = $writer->uploadTables(
             $root . "/upload",
             [
                 "mapping" => [
@@ -1008,6 +1008,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ],
             ['componentId' => 'foo']
         );
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
         $tableInfo = $this->client->getTable("out.c-docker-test.table14");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
 

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -326,8 +326,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(2, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
-        $this->client->waitForJob($jobIds[1]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(2, $tables);
@@ -354,12 +353,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer($this->client, new NullLogger());
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         // And again
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -383,7 +382,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -435,7 +434,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -459,7 +458,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -504,7 +503,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-default-test");
         $this->assertCount(1, $tables);
@@ -537,7 +536,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-redshift-test");
         $this->assertCount(1, $tables);
@@ -611,7 +610,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -630,7 +629,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -660,12 +659,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         // And again, check first incremental table
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $exporter = new TableExporter($this->client);
         $exporter->exportTable("out.c-docker-default-test.table51", $root . DIRECTORY_SEPARATOR . "download.csv", []);
@@ -705,12 +704,12 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         // And again, check first incremental table
         $jobIds = $writer->uploadTables($root . "/upload", ["mapping" => $configs], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $exporter = new TableExporter($this->client);
         $exporter->exportTable("out.c-docker-redshift-test.table61", $root . DIRECTORY_SEPARATOR . "download.csv", []);
@@ -765,8 +764,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ["bucket" => "in.c-docker-test"], ['componentId' => 'foo']);
         $this->assertCount(2, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
-        $this->client->waitForJob($jobIds[1]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("in.c-docker-test");
         $this->assertCount(2, $tables);
@@ -797,8 +795,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $tableInfo = $this->client->getTable('out.c-docker-test.table5');
         $this->assertEquals(["Id", "Name"], $tableInfo["columns"]);
 
-        // let the test fully finish before starting another one
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
     }
 
     public function testWriteTableManifestWithDefaultBucket()
@@ -817,7 +814,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
 
         $jobIds = $writer->uploadTables($root . "/upload", ['bucket' => 'out.c-docker-test'], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -845,7 +842,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -944,7 +941,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
         $tableInfo = $this->client->getTable("out.c-docker-test.table16");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
     }
@@ -984,7 +981,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $tableInfo = $this->client->getTable("out.c-docker-test.table15");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
@@ -1009,7 +1006,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
         $tableInfo = $this->client->getTable("out.c-docker-test.table14");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
 
@@ -1056,7 +1053,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
         $tableInfo = $this->client->getTable("out.c-docker-test.table13");
         $this->assertEquals(["Id"], $tableInfo["primaryKey"]);
 
@@ -1124,7 +1121,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
         $this->assertFalse($handler->hasWarningThatContains("Output mapping does not match destination table"));
         $tableInfo = $this->client->getTable("out.c-docker-test.table12");
         $this->assertEquals([], $tableInfo["primaryKey"]);
@@ -1152,7 +1149,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
 
         $writer = new Writer($this->client, (new Logger("null"))->pushHandler($handler));
         file_put_contents(
@@ -1161,7 +1158,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         );
         $jobIds = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         $this->assertCount(1, $jobIds);
-        $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
         $this->assertFalse(
             $handler->hasWarningThatContains(
                 "Output mapping does not match destination table: primary key '' does not match '' in 'out.c-docker-test.table9'."
@@ -1194,7 +1191,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ['componentId' => 'foo']
         );
         $this->assertCount(1, $jobIds);
-        $job = $this->client->waitForJob($jobIds[0]);
+        $this->client->handleAsyncTasks($jobIds);
         $this->assertEquals('error', $job['status']);
         $this->assertContains(
             'Some columns are missing in the csv file. Missing columns: id,name.',

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -528,6 +528,8 @@ class Writer
                     $jobId = '';
                 }
             } else {
+                $options["delimiter"] = $config["delimiter"];
+                $options["enclosure"] = $config["enclosure"];
                 $fileId = $this->client->uploadFile($source, (new FileUploadOptions())->setCompress(true));
                 $options['dataFileId'] = $fileId;
                 $options['name'] = $tableName;
@@ -570,6 +572,8 @@ class Writer
                         $jobId = '';
                     }
                 } else {
+                    $options["delimiter"] = $config["delimiter"];
+                    $options["enclosure"] = $config["enclosure"];
                     $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
                     $fileId = $this->client->uploadFile($csvFile->getPathname(), new FileUploadOptions());
                     $options['dataFileId'] = $fileId;
@@ -579,6 +583,8 @@ class Writer
             } else {
                 $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
                 if ($deferred) {
+                    $options["delimiter"] = $config["delimiter"];
+                    $options["enclosure"] = $config["enclosure"];
                     $tmp = new Temp();
                     $headerCsvFile = new CsvFile($tmp->createFile($tableName . '.header.csv'));
                     $headerCsvFile->writeRow($csvFile->getHeader());
@@ -588,6 +594,8 @@ class Writer
                     $options['dataFileId'] = $fileId;
                     $jobId = $this->client->queueTableImport($tableId, $options);
                 } else {
+                    $options["delimiter"] = $config["delimiter"];
+                    $options["enclosure"] = $config["enclosure"];
                     $fileId = $this->client->uploadFile($csvFile->getPathname(), (new FileUploadOptions())->setCompress(true));
                     $options['dataFileId'] = $fileId;
                     $options['name'] = $tableName;

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -547,7 +547,6 @@ class Writer
                 if (is_dir($source)) {
                     $fileId = $this->uploadSlicedFile($source);
                     $options['dataFileId'] = $fileId;
-                    // write table
                     $jobId = $this->client->queueTableImport($config['destination'], $options);
                 } else {
                     $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -560,7 +560,15 @@ class Writer
                 if (is_dir($source)) {
                     $options["delimiter"] = $config["delimiter"];
                     $options["enclosure"] = $config["enclosure"];
-                    $jobId = $this->writeSlicedTable($deferred, $source, $config["destination"], $options);
+                    $fileId = $this->uploadSlicedFile($source);
+                    $options['dataFileId'] = $fileId;
+                    // write table
+                    if ($deferred) {
+                        $jobId = $this->client->queueTableImport($config['destination'], $options);
+                    } else {
+                        $this->client->writeTableAsyncDirect($config['destination'], $options);
+                        $jobId = '';
+                    }
                 } else {
                     $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
                     $fileId = $this->client->uploadFile($csvFile->getPathname(), new FileUploadOptions());

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -461,6 +461,7 @@ class Writer
             );
         }
 
+        $jobId = null;
         if ($this->client->tableExists($config["destination"])) {
             $tableInfo = $this->client->getTable($config["destination"]);
             $this->validateAgainstTable($tableInfo, $config);
@@ -524,7 +525,6 @@ class Writer
                     $jobId = $this->client->queueTableImport($config['destination'], $options);
                 } else {
                     $this->client->writeTableAsyncDirect($config['destination'], $options);
-                    $jobId = '';
                 }
             } else {
                 $fileId = $this->client->uploadFile($source, (new FileUploadOptions())->setCompress(true));
@@ -534,7 +534,6 @@ class Writer
                     $jobId = $this->client->queueTableImport($config['destination'], $options);
                 } else {
                     $this->client->writeTableAsyncDirect($config['destination'], $options);
-                    $jobId = '';
                 }
             }
 
@@ -566,7 +565,6 @@ class Writer
                         $jobId = $this->client->queueTableImport($config['destination'], $options);
                     } else {
                         $this->client->writeTableAsyncDirect($config['destination'], $options);
-                        $jobId = '';
                     }
                 } else {
                     $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
@@ -600,7 +598,6 @@ class Writer
                     $options['dataFileId'] = $fileId;
                     $options['name'] = $tableName;
                     $tableId = $this->client->createTableAsyncDirect($bucketId, $options);
-                    $jobId = '';
                 }
                 unset($csvFile);
             }

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -547,7 +547,9 @@ class Writer
                     $jobId = $this->writeSlicedTable($deferred, $source, $config["destination"], $options);
                 } else {
                     $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
-                    $jobId = $this->writeTableAsync($deferred, $config["destination"], $csvFile, $options);
+                    $fileId = $this->client->uploadFile($csvFile->getPathname(), new FileUploadOptions());
+                    $options['dataFileId'] = $fileId;
+                    $jobId = $this->client->queueTableImport($config["destination"], $options);
                     unset($csvFile);
                 }
             } else {
@@ -558,7 +560,9 @@ class Writer
                     $headerCsvFile->writeRow($csvFile->getHeader());
                     $tableId = $this->client->createTableAsync($bucketId, $tableName, $headerCsvFile, $options);
                     unset($headerCsvFile);
-                    $jobId = $this->writeTableAsync($deferred, $tableId, $csvFile, $options);
+                    $fileId = $this->client->uploadFile($csvFile->getPathname(), new FileUploadOptions());
+                    $options['dataFileId'] = $fileId;
+                    $jobId = $this->client->queueTableImport($tableId, $options)['id'];
                 } else {
                     $tableId = $this->client->createTableAsync($bucketId, $tableName, $csvFile, $options);
                     $jobId = '';

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "symfony/finder": "^2.8|^4.1",
         "symfony/serializer": "^2.8|^4.1",
         "monolog/monolog": "^1.22",
-        "keboola/storage-api-client": "^10.0",
-        "keboola/input-mapping": "^6.0",
+        "keboola/storage-api-client": "dev-najlos-fire-and-forget-workspace-loads",
+        "keboola/input-mapping": "dev-odin-update@dev",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         "symfony/finder": "^2.8|^4.1",
         "symfony/serializer": "^2.8|^4.1",
         "monolog/monolog": "^1.22",
-        "keboola/storage-api-client": "dev-najlos-fire-and-forget-workspace-loads",
-        "keboola/input-mapping": "dev-odin-update@dev",
+        "keboola/input-mapping": "^6.0",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {


### PR DESCRIPTION
- feat: remove deferred parameter and make asynchronous imports default
- feat: remove support for importing GZ files
- refactor: take advantage of the recently added queue method available in Storage API client
- refactor: remove synchronous imports
- tests: added job waits to tests to avoid race conditions https://keboola.slack.com/archives/CD6CWCXD3/p1546445427003900
- tests: renamed created tables to ease debugging ^