### PR TITLE
fix: column metadata for added columns

### DIFF
--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -186,9 +186,17 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $jobIds);
         $this->client->waitForJob($jobIds[0]);
 
+        $rows = [];
+        for ($i = 0; $i < 10000; $i++) {
+            $rows[] = sprintf('"%s","%s","%s"', $i, uniqid('name-'), uniqid('foo'));
+        }
+        $rows[] = '';
         file_put_contents(
             $root . "/upload/table88.csv",
-            "\"Id\",\"Name\",\"Foo\"\n\"test\",\"test\",\"bar\"\n\"aabb\",\"ccdd\",\"eeff\"\n"
+            implode(
+                "\n",
+                $rows
+            )
         );
         $config = [
             "mapping" => [

--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -315,20 +315,20 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($idColMetadata));
-        $NameColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test-backend.table99.Name');
+        $nameColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test-backend.table99.Name');
         $expectedColumnMetadata = [
             'testComponent' => [
                 'column.key.one' => 'column value one text2',
             ]
         ];
-        $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($NameColMetadata));
-        $FooColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test-backend.table99.Foo');
+        $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($nameColMetadata));
+        $fooColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test-backend.table99.Foo');
         $expectedColumnMetadata = [
             'testComponent' => [
                 'foo.one' => 'bar one',
             ]
         ];
-        $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($FooColMetadata));
+        $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($fooColMetadata));
     }
 
     public function testConfigRowMetadataWritingTest()

--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -235,7 +235,7 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         $NameColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test.table88.Name');
         $expectedColumnMetadata = [
             'testComponent' => [
-                'column.key.two' => 'column value one text2',
+                'column.key.one' => 'column value one text2',
             ]
         ];
         $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($NameColMetadata));

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -508,6 +508,9 @@ class Writer
                 "delimiter" => $config["delimiter"],
                 "enclosure" => $config["enclosure"],
             ];
+            $newColumns = $this->getNewColumns($tableInfo['columns'], $config['columns'], $this->getPhysicalColumns($source));
+            $this->addColumns($config['destination'], $newColumns);
+
             // headless csv file
             if (!empty($config["columns"])) {
                 $options["columns"] = $config["columns"];
@@ -720,5 +723,45 @@ class Writer
             return true;
         }
         return false;
+    }
+
+    /**
+     * @param string $source Table source file
+     * @return array Columns found in the file
+     */
+    private function getPhysicalColumns($source)
+    {
+        if (!is_dir($source)) {
+            $csv = new CsvFile($source);
+            return $csv->getHeader();
+        }
+        return [];
+    }
+
+    /**
+     * @param array $currentColumns Current columns of a table.
+     * @param array $declaredColumns Declared columns of the new table.
+     * @param array $physicalColumns Physical columns of the new table.
+     * @return array Added columns
+     */
+    private function getNewColumns(array $currentColumns, array $declaredColumns, array $physicalColumns)
+    {
+        if ($declaredColumns) {
+            $newColumns = $declaredColumns;
+        } else {
+            $newColumns = $physicalColumns;
+        }
+        return array_diff($newColumns, $currentColumns);
+    }
+
+    /**
+     * @param string $destination Table ID
+     * @param array $newColumns Names of new table columns
+     */
+    private function addColumns($destination, array $newColumns)
+    {
+        foreach ($newColumns as $column) {
+            $this->client->addTableColumn($destination, $column);
+        }
     }
 }


### PR DESCRIPTION
fixes: https://github.com/keboola/output-mapping/issues/26

when a table is imported with more columns than physically present in the table structure, the new columns are added before the actual import so that metadata for them can be set.

depends on https://github.com/keboola/output-mapping/pull/25