### PR TITLE
fix: adding columns when non-standard CSV delimiter is used

### DIFF
--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -256,6 +256,74 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
      * @throws ClientException
      * @throws \Keboola\Csv\Exception
      */
+    public function testMetadataWritingTestColumnChangeSpecialDelimiter($backend)
+    {
+        $this->client->createBucket('docker-test-backend', "in", '', $backend);
+        $root = $this->tmp->getTmpFolder();
+        $csv = new CsvFile($root . "/table88a.csv");
+        $csv->writeRow(['Id with special chars', 'Name']);
+        $csv->writeRow(['test', 'test']);
+        $csv->writeRow(['aabb', 'ccdd']);
+        $this->client->createTableAsync('in.c-docker-test-backend', 'table88', $csv);
+
+        $csv = new CsvFile($root . "/upload/table88b.csv", ';', '@');
+        $csv->writeRow(['Id with special chars', 'Name', 'Foo']);
+        $csv->writeRow(['test', 'test', 'bar']);
+        $csv->writeRow(['aabb', 'ccdd', 'baz']);
+        unset($csv);
+        $config = [
+            "mapping" => [
+                [
+                    "source" => "table88b.csv",
+                    "destination" => "in.c-docker-test-backend.table88",
+                    "delimiter" => ";",
+                    "enclosure" => "@",
+                    "metadata" => [],
+                    "column_metadata" => [
+                        "Name" => [
+                            [
+                                "key" => "column.key.one",
+                                "value" => "column value one text2"
+                            ],
+                        ],
+                        "Foo" => [
+                            [
+                                "key" => "foo.one",
+                                "value" => "bar one",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $writer = new Writer($this->client, new NullLogger());
+        $jobIds = $writer->uploadTables($root . "/upload", $config, ["componentId" => "testComponent"]);
+        $this->assertCount(1, $jobIds);
+        $this->client->waitForJob($jobIds[0]);
+
+        $metadataApi = new Metadata($this->client);
+        $nameColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test-backend.table88.Name');
+        $expectedColumnMetadata = [
+            'testComponent' => [
+                'column.key.one' => 'column value one text2',
+            ]
+        ];
+        $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($nameColMetadata));
+        $fooColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test-backend.table88.Foo');
+        $expectedColumnMetadata = [
+            'testComponent' => [
+                'foo.one' => 'bar one',
+            ]
+        ];
+        $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($fooColMetadata));
+    }
+
+    /**
+     * @dataProvider backendProvider
+     * @param string $backend
+     * @throws ClientException
+     * @throws \Keboola\Csv\Exception
+     */
     public function testMetadataWritingTestColumnChangeSpecialChars($backend)
     {
         $this->client->createBucket('docker-test-backend', "in", '', $backend);

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -509,7 +509,11 @@ class Writer
                 "delimiter" => $config["delimiter"],
                 "enclosure" => $config["enclosure"],
             ];
-            $newColumns = $this->getNewColumns($tableInfo['columns'], $config['columns'], $this->getPhysicalColumns($source));
+            $newColumns = $this->getNewColumns(
+                $tableInfo['columns'],
+                $config['columns'],
+                $this->getPhysicalColumns($source, $config["delimiter"], $config["enclosure"])
+            );
             $this->addColumns($config['destination'], $newColumns);
 
             // headless csv file
@@ -728,12 +732,14 @@ class Writer
 
     /**
      * @param string $source Table source file
+     * @param string $delimiter CSV delimiter
+     * @param string $enclosure CSV enclosure
      * @return array Columns found in the file
      */
-    private function getPhysicalColumns($source)
+    private function getPhysicalColumns($source, $delimiter, $enclosure)
     {
         if (!is_dir($source)) {
-            $csv = new CsvFile($source);
+            $csv = new CsvFile($source, $delimiter, $enclosure);
             return $csv->getHeader();
         }
         return [];


### PR DESCRIPTION
- fixes column detection for non-standard delimiter CSV
- possibly replaced by https://github.com/keboola/output-mapping/pull/32