### PR TITLE
handle csv error gracefuly

### DIFF
--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -1156,8 +1156,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             '{"destination": "out.c-docker-test.table11","primary_key": [""]}'
         );
         $tableQueue =  $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
-        $this->assertCount(1, $jobIds);
         $jobIds = $tableQueue->waitForAll();
+        $this->assertCount(1, $jobIds);
         $this->assertFalse(
             $handler->hasWarningThatContains(
                 "Output mapping does not match destination table: primary key '' does not match '' in 'out.c-docker-test.table9'."
@@ -1172,9 +1172,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $root = $this->tmp->getTmpFolder();
         file_put_contents($root . "/upload/out.c-docker-test.table10.csv", "\"Id\",\"Name\"\n\"test\",\"test\"\n");
         $writer = new Writer($this->client, new NullLogger());
-        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
-        $root = $this->tmp->getTmpFolder();
-        file_put_contents($root . "/upload/out.c-docker-test.table10.csv", "\"foo\",\"bar\"\n\"baz\",\"bat\"\n");
+        $tableQueue = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        $tableQueue->waitForAll();
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(1, $tables);
@@ -1183,6 +1182,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $tableInfo = $this->client->getTable('out.c-docker-test.table10');
         $this->assertEquals(["Id", "Name"], $tableInfo["columns"]);
 
+        file_put_contents($root . "/upload/out.c-docker-test.table10.csv", "\"foo\",\"bar\"\n\"baz\",\"bat\"\n");
         $writer = new Writer($this->client, new NullLogger());
         $tableQueue =  $writer->uploadTables(
             $root . "/upload",
@@ -1205,6 +1205,7 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             ["mapping" => [["source" => "out.c-docker-test.table10a.csv"], ["source" => "out.c-docker-test.table10b.csv"]]],
             ['componentId' => 'foo']
         );
+        $tableQueue->waitForAll();
 
         $tables = $this->client->listTables("out.c-docker-test");
         $this->assertCount(2, $tables);

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -1249,9 +1249,8 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
         $root = $this->tmp->getTmpFolder();
         file_put_contents($root . "/upload/out.c-docker-test.table10.csv", "\"Id\",\"Name\"\r\"test\",\"test\"\r");
         $writer = new Writer($this->client, new NullLogger());
-        $tableQueue = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
         self::expectException(InvalidOutputException::class);
-        self::expectExceptionMessage('Some columns are missing in the csv file. Missing columns: id,name.');
-        $tableQueue->waitForAll();
+        self::expectExceptionMessage('Invalid line break. Please use unix \n or win \r\n line breaks.');
+        $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
     }
 }

--- a/Tests/StorageApiWriterTest.php
+++ b/Tests/StorageApiWriterTest.php
@@ -1243,4 +1243,15 @@ class StorageApiWriterTest extends \PHPUnit_Framework_TestCase
             );
         }
     }
+
+    public function testWriteTableInvalidCsv()
+    {
+        $root = $this->tmp->getTmpFolder();
+        file_put_contents($root . "/upload/out.c-docker-test.table10.csv", "\"Id\",\"Name\"\r\"test\",\"test\"\r");
+        $writer = new Writer($this->client, new NullLogger());
+        $tableQueue = $writer->uploadTables($root . "/upload", [], ['componentId' => 'foo']);
+        self::expectException(InvalidOutputException::class);
+        self::expectExceptionMessage('Some columns are missing in the csv file. Missing columns: id,name.');
+        $tableQueue->waitForAll();
+    }
 }

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -566,9 +566,8 @@ class Writer
                     $options['dataFileId'] = $fileId;
                     $tableQueue =  new LoadTable($this->client, $config['destination'], $options);
                 } else {
-                    $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
                     $fileId = $this->client->uploadFile(
-                        $csvFile->getPathname(),
+                        $source,
                         (new FileUploadOptions())->setCompress(true)
                     );
                     $options['dataFileId'] = $fileId;

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -3,6 +3,7 @@
 namespace Keboola\OutputMapping\Writer;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Csv\Exception;
 use Keboola\InputMapping\Reader\Reader;
 use Keboola\OutputMapping\Configuration\File\Manifest as FileManifest;
 use Keboola\OutputMapping\Configuration\File\Manifest\Adapter as FileAdapter;
@@ -575,7 +576,11 @@ class Writer
                     unset($csvFile);
                 }
             } else {
-                $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
+                try {
+                    $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
+                } catch (Exception $e) {
+                    throw new InvalidOutputException('Failed to read file ' . $source . ' ' . $e->getMessage());
+                }
                 $tmp = new Temp();
                 $headerCsvFile = new CsvFile($tmp->createFile($tableName . '.header.csv'));
                 $headerCsvFile->writeRow($csvFile->getHeader());

--- a/Writer/Writer.php
+++ b/Writer/Writer.php
@@ -578,12 +578,13 @@ class Writer
             } else {
                 try {
                     $csvFile = new CsvFile($source, $config["delimiter"], $config["enclosure"]);
+                    $header = $csvFile->getHeader();
                 } catch (Exception $e) {
                     throw new InvalidOutputException('Failed to read file ' . $source . ' ' . $e->getMessage());
                 }
                 $tmp = new Temp();
                 $headerCsvFile = new CsvFile($tmp->createFile($tableName . '.header.csv'));
-                $headerCsvFile->writeRow($csvFile->getHeader());
+                $headerCsvFile->writeRow($header);
                 $tableId = $this->client->createTableAsync($bucketId, $tableName, $headerCsvFile, $options);
                 unset($headerCsvFile);
                 $fileId = $this->client->uploadFile(


### PR DESCRIPTION
fixes #33 

jsou tam fixnuty lehce nesouvisejci bugy v testech:
assertion https://github.com/keboola/output-mapping/pull/34/files#diff-f04cb5f6acd46720e4600bc67500a25cR1160 byla na nesmyslnym miste
pridany wait na job https://github.com/keboola/output-mapping/pull/34/files#diff-f04cb5f6acd46720e4600bc67500a25cR1176 a https://github.com/keboola/output-mapping/pull/34/files#diff-f04cb5f6acd46720e4600bc67500a25cR1208 - nema to na nic vliv, ale pro zichr
a posunutej file upload https://github.com/keboola/output-mapping/pull/34/files#diff-f04cb5f6acd46720e4600bc67500a25cR1185 na logictejsi misto
