### PR TITLE
sanitize column names

### DIFF
--- a/DeferredTasks/MetadataDefinition.php
+++ b/DeferredTasks/MetadataDefinition.php
@@ -4,6 +4,7 @@ namespace Keboola\OutputMapping\DeferredTasks;
 
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Metadata;
+use Keboola\Utils\Sanitizer\ColumnNameSanitizer;
 
 class MetadataDefinition
 {
@@ -49,7 +50,7 @@ class MetadataDefinition
         if ($this->type === self::COLUMN_METADATA) {
             $metadataClient = new Metadata($this->client);
             foreach ($this->metadata as $column => $metadataArray) {
-                $columnId = $this->destination . "." . $column;
+                $columnId = $this->destination . '.' . ColumnNameSanitizer::sanitize($column);
                 $metadataClient->postColumnMetadata($columnId, $this->provider, $metadataArray);
             }
         } elseif ($this->type === self::TABLE_METADATA) {

--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -407,6 +407,15 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $jobIds);
 
         $metadataApi = new Metadata($this->client);
+        $idColMetadata = $metadataApi->listColumnMetadata(
+            'in.c-docker-test-backend.table88.Id_with_special_chars'
+        );
+        $expectedColumnMetadata = [
+            'testComponent' => [
+                'column.key.zero' => 'column value on id',
+            ]
+        ];
+        $this->assertEquals($expectedColumnMetadata, $this->getMetadataValues($idColMetadata));
         $nameColMetadata = $metadataApi->listColumnMetadata('in.c-docker-test-backend.table88.Name');
         $expectedColumnMetadata = [
             'testComponent' => [

--- a/Tests/StorageApiWriterMetadataTest.php
+++ b/Tests/StorageApiWriterMetadataTest.php
@@ -379,10 +379,16 @@ class StorageApiWriterMetadataTest extends \PHPUnit_Framework_TestCase
                     "destination" => "in.c-docker-test-backend.table88",
                     "metadata" => [],
                     "column_metadata" => [
+                        "Id with special chars" => [
+                            [
+                                "key" => "column.key.zero",
+                                "value" => "column value on id",
+                            ],
+                        ],
                         "Name" => [
                             [
                                 "key" => "column.key.one",
-                                "value" => "column value one text2"
+                                "value" => "column value one text2",
                             ],
                         ],
                         "Foo" => [


### PR DESCRIPTION
fix: handle columns with special characters when adding metadata, fixes #39