### PR TITLE
fix: remove target dir incompatible with psr4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "keboola/php-temp": "^1.0",
         "phpunit/phpunit": "^5.4"
     },
-    "target-dir": "Keboola/OutputMapping",
     "scripts": {
         "tests": "phpunit",
         "phpcs": "phpcs --standard=psr2 --ignore=vendor -n /code",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
          bootstrap="bootstrap.php">
 
     <testsuite name="Test Suite">
-        <directory>Tests</directory>
+        <directory>tests</directory>
     </testsuite>
 
     <filter>


### PR DESCRIPTION
prislo mailem

```
Skipped branch master, Invalid package information: 
target-dir : this can not be used together with the autoload.psr-4 setting, remove target-dir to upgrade to psr-4

Reading composer.json of keboola/output-mapping (odin-targetdir-quickfix)
Importing branch odin-targetdir-quickfix (dev-odin-targetdir-quickfix)
```