### PR TITLE
Undefined destination fixes

### DIFF
--- a/src/Writer/TableWriter.php
+++ b/src/Writer/TableWriter.php
@@ -114,24 +114,13 @@ class TableWriter extends AbstractWriter
 
             if ($manifest !== false) {
                 $configFromManifest = $this->readTableManifest($manifest->getPathname());
-                if (empty($configFromManifest['destination']) || isset($configuration['bucket'])) {
-                    $configFromManifest['destination'] = $this->createDestinationConfigParam(
-                        $prefix,
-                        $manifest->getBasename('.manifest')
-                    );
-                }
-            } else {
-                // If no manifest found and no output mapping, use filename (without .csv if present) as table id
-                if (empty($configFromMapping['destination']) || isset($configuration['bucket'])) {
-                    $configFromMapping['destination'] = $this->createDestinationConfigParam(
-                        $prefix,
-                        $manifest->getBasename('.manifest')
-                    );
-                }
             }
 
             try {
                 $mergedConfig = ConfigurationMerger::mergeConfigurations($configFromManifest, $configFromMapping);
+                if (empty($mergedConfig['destination'])) {
+                    throw new InvalidOutputException(sprintf('Failed to resolve destination for output table "%s".', $sourceName));
+                }
                 $parsedConfig = (new TableManifest())->parse([$mergedConfig]);
             } catch (InvalidConfigurationException $e) {
                 throw new InvalidOutputException(

--- a/tests/Writer/AbsWriterWorkspaceTest.php
+++ b/tests/Writer/AbsWriterWorkspaceTest.php
@@ -141,7 +141,6 @@ class AbsWriterWorkspaceTest extends BaseWriterWorkspaceTest
         $data = $this->clientWrapper->getBasicClient()->getTableDataPreview('out.c-output-mapping-test.table1a');
         $rows = explode("\n", trim($data));
         sort($rows);
-        // column name is lowercase because of https://keboola.atlassian.net/browse/KBC-864
         $this->assertEquals(['"Id","Name"', '"aabb","ccdd"', '"test","test"'], $rows);
     }
 
@@ -168,7 +167,7 @@ class AbsWriterWorkspaceTest extends BaseWriterWorkspaceTest
         file_put_contents(
             $root . '/data/out/tables/table1a.csv.manifest',
             json_encode(
-                ['columns' => ['first column', 'second column']]
+                ['columns' => ['First column', 'Second column']]
             )
         );
 
@@ -189,13 +188,12 @@ class AbsWriterWorkspaceTest extends BaseWriterWorkspaceTest
         $job = $this->clientWrapper->getBasicClient()->getJob($jobIds[0]);
         $this->assertEquals('out.c-output-mapping-test.table1a', $job['tableId']);
         $this->assertEquals(false, $job['operationParams']['params']['incremental']);
-        $this->assertEquals(['first column', 'second column'], $job['operationParams']['params']['columns']);
+        $this->assertEquals(['First column', 'Second column'], $job['operationParams']['params']['columns']);
         $data = $this->clientWrapper->getBasicClient()->getTableDataPreview('out.c-output-mapping-test.table1a');
         $rows = explode("\n", trim($data));
         sort($rows);
-        // column name is lowercase because of https://keboola.atlassian.net/browse/KBC-864
         $this->assertEquals(
-            ['"first value","second value"', '"first_column","second_column"', '"secondRow1","secondRow2"'],
+            ['"First_column","Second_column"', '"first value","second value"', '"secondRow1","secondRow2"'],
             $rows
         );
     }

--- a/tests/Writer/WriterWorkspaceTest.php
+++ b/tests/Writer/WriterWorkspaceTest.php
@@ -219,6 +219,64 @@ class WriterWorkspaceTest extends BaseWriterWorkspaceTest
         );
     }
 
+    public function testTableOutputMappingMissingDestinationManifest()
+    {
+        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $factory = $this->getStagingFactory(null, 'json', null, [StrategyFactory::WORKSPACE_SNOWFLAKE, $tokenInfo['owner']['defaultBackend']]);
+        // initialize the workspace mock
+        $factory->getTableOutputStrategy(StrategyFactory::WORKSPACE_SNOWFLAKE)->getDataStorage()->getWorkspaceId();
+        $root = $this->tmp->getTmpFolder();
+        $configs = [
+            [
+                'source' => 'table1a',
+                'incremental' => true,
+                'columns' => ['Id'],
+            ]
+        ];
+        $writer = new TableWriter($factory);
+        file_put_contents(
+            $root . '/table1a.manifest',
+            json_encode(
+                ['columns' => ['Id', 'Name']]
+            )
+        );
+
+        self::expectException(InvalidOutputException::class);
+        self::expectExceptionMessage('Failed to resolve destination for output table "table1a".');
+        $writer->uploadTables(
+            '/',
+            ['mapping' => $configs],
+            ['componentId' => 'foo'],
+            'workspace-snowflake'
+        );
+    }
+
+    public function testTableOutputMappingMissingDestinationNoManifest()
+    {
+        $tokenInfo = $this->clientWrapper->getBasicClient()->verifyToken();
+        $factory = $this->getStagingFactory(null, 'json', null, [StrategyFactory::WORKSPACE_SNOWFLAKE, $tokenInfo['owner']['defaultBackend']]);
+        // initialize the workspace mock
+        $factory->getTableOutputStrategy(StrategyFactory::WORKSPACE_SNOWFLAKE)->getDataStorage()->getWorkspaceId();
+        $root = $this->tmp->getTmpFolder();
+        $configs = [
+            [
+                'source' => 'table1a',
+                'incremental' => true,
+                'columns' => ['Id'],
+            ]
+        ];
+        $writer = new TableWriter($factory);
+
+        self::expectException(InvalidOutputException::class);
+        self::expectExceptionMessage('Failed to resolve destination for output table "table1a".');
+        $writer->uploadTables(
+            '/',
+            ['mapping' => $configs],
+            ['componentId' => 'foo'],
+            'workspace-snowflake'
+        );
+    }
+
     public function testRedshiftTableOutputMapping()
     {
         $factory = $this->getStagingFactory(null, 'json', null, [StrategyFactory::WORKSPACE_REDSHIFT, 'redshift']);


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-1648

This was broken from the beginning of the workspace implementation. Destination is required in the UI (but not required in the config definition, because it can come up from different places) so this is somewhat of an edge case. 
