### PR TITLE
PS-2110 support tableFiles

### DIFF
--- a/src/Configuration/Table.php
+++ b/src/Configuration/Table.php
@@ -18,12 +18,6 @@ class Table extends Configuration
     public static function configureNode(NodeDefinition $node)
     {
         Table\Manifest::configureNode($node);
-
-        $node->children()
-            ->scalarNode("source")->isRequired()->end()
-            ->arrayNode('file_tags')
-                ->prototype('scalar')->end()
-            ->end()
-        ;
+        $node->children()->scalarNode("source")->isRequired()->end();
     }
 }

--- a/src/Configuration/TableFile.php
+++ b/src/Configuration/TableFile.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Keboola\OutputMapping\Configuration;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class TableFile extends Configuration
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $root = $treeBuilder->root("tableFile");
+        self::configureNode($root);
+        return $treeBuilder;
+    }
+
+    public static function configureNode(NodeDefinition $node)
+    {
+        $node
+            ->children()
+            ->arrayNode("tags")->prototype("scalar")->end()->end()
+            ->booleanNode("is_permanent")->defaultValue(true)->end()
+        ;
+    }
+}
+

--- a/src/Configuration/TableFile.php
+++ b/src/Configuration/TableFile.php
@@ -24,4 +24,3 @@ class TableFile extends Configuration
         ;
     }
 }
-

--- a/src/Writer/FileWriter.php
+++ b/src/Writer/FileWriter.php
@@ -4,6 +4,7 @@ namespace Keboola\OutputMapping\Writer;
 
 use Keboola\InputMapping\Reader;
 use Keboola\OutputMapping\Configuration\File\Manifest as FileManifest;
+use Keboola\OutputMapping\Configuration\TableFile;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Exception\OutputOperationException;
 use Keboola\OutputMapping\Writer\Helper\TagsHelper;
@@ -79,7 +80,7 @@ class FileWriter extends AbstractWriter
             try {
                 if (!empty($tableFiles)) {
                     // tableFiles take highest priority
-                    $storageConfig = (new FileManifest())->parse([$tableFiles]);
+                    $storageConfig = (new TableFile())->parse([$tableFiles]);
                 } elseif ($configFromMapping || !$configFromManifest) {
                     // Mapping with higher priority than manifest
                     $storageConfig = (new FileManifest())->parse([$configFromMapping]);

--- a/src/Writer/FileWriter.php
+++ b/src/Writer/FileWriter.php
@@ -19,8 +19,9 @@ class FileWriter extends AbstractWriter
      * @param array $configuration Upload configuration
      * @param array $systemMetadata Metadata identifying the source of the file
      * @param string $storage Currently any storage that is not ABS workspaces defaults to local
+     * @param array $tableFiles For the use file storage only case, tags etc are provided here
      */
-    public function uploadFiles($source, $configuration, $systemMetadata, $storage)
+    public function uploadFiles($source, $configuration, $systemMetadata, $storage, $tableFiles = [])
     {
         if (!empty($systemMetadata) && empty($systemMetadata[self::SYSTEM_KEY_COMPONENT_ID])) {
             throw new OutputOperationException('Component Id must be set');
@@ -71,7 +72,7 @@ class FileWriter extends AbstractWriter
                 }
             }
             $manifestKey = $file->getPathName() . '.manifest';
-            if (isset($manifests[$manifestKey])) {
+            if (isset($manifests[$manifestKey]) && empty($tableFiles)) {
                 $configFromManifest = $strategy->readFileManifest($file->getPathName() . '.manifest');
                 unset($manifests[$manifestKey]);
             }
@@ -79,6 +80,9 @@ class FileWriter extends AbstractWriter
                 // Mapping with higher priority
                 if ($configFromMapping || !$configFromManifest) {
                     $storageConfig = (new FileManifest())->parse([$configFromMapping]);
+                } elseif (!empty($tableFiles)) {
+                    // create storageConfig from the $tableFiles data
+                    $storageConfig = (new FileManifest())->parse([$tableFiles]);
                 } else {
                     $storageConfig = (new FileManifest())->parse([$configFromManifest]);
                 }

--- a/src/Writer/FileWriter.php
+++ b/src/Writer/FileWriter.php
@@ -77,12 +77,12 @@ class FileWriter extends AbstractWriter
                 unset($manifests[$manifestKey]);
             }
             try {
-                // Mapping with higher priority
-                if ($configFromMapping || !$configFromManifest) {
-                    $storageConfig = (new FileManifest())->parse([$configFromMapping]);
-                } elseif (!empty($tableFiles)) {
-                    // create storageConfig from the $tableFiles data
+                if (!empty($tableFiles)) {
+                    // tableFiles take highest priority
                     $storageConfig = (new FileManifest())->parse([$tableFiles]);
+                } elseif ($configFromMapping || !$configFromManifest) {
+                    // Mapping with higher priority than manifest
+                    $storageConfig = (new FileManifest())->parse([$configFromMapping]);
                 } else {
                     $storageConfig = (new FileManifest())->parse([$configFromManifest]);
                 }

--- a/src/Writer/FileWriter.php
+++ b/src/Writer/FileWriter.php
@@ -73,6 +73,7 @@ class FileWriter extends AbstractWriter
                 }
             }
             $manifestKey = $file->getPathName() . '.manifest';
+            // If $tableFiles are supplied then we don't want the manifest because it'll be a table manifest
             if (isset($manifests[$manifestKey]) && empty($tableFiles)) {
                 $configFromManifest = $strategy->readFileManifest($file->getPathName() . '.manifest');
                 unset($manifests[$manifestKey]);

--- a/src/Writer/TableWriter.php
+++ b/src/Writer/TableWriter.php
@@ -113,7 +113,7 @@ class TableWriter extends AbstractWriter
                 foreach ($configuration['mapping'] as $mapping) {
                     if (isset($mapping['source']) && $mapping['source'] === $sourceName) {
                         $configFromMapping = $mapping;
-                        unset($configFromMapping['source'], $configFromMapping['file_tags']);
+                        unset($configFromMapping['source']);
                     }
                 }
             }
@@ -249,7 +249,7 @@ class TableWriter extends AbstractWriter
                     if (isset($mapping['source']) && $mapping['source'] === $file->getFilename()) {
                         $configFromMapping = $mapping;
                         $processedOutputMappingTables[] = $configFromMapping['source'];
-                        unset($configFromMapping['source'], $configFromMapping['file_tags']);
+                        unset($configFromMapping['source']);
                     }
                 }
             }

--- a/tests/Configuration/TableFileTest.php
+++ b/tests/Configuration/TableFileTest.php
@@ -3,6 +3,7 @@
 namespace Keboola\OutputMapping\Tests\Configuration;
 
 use Keboola\OutputMapping\Configuration\TableFile;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class TableFileTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,5 +19,15 @@ class TableFileTest extends \PHPUnit_Framework_TestCase
         ];
         $processedConfiguration = (new TableFile())->parse(['config' => $config]);
         $this->assertEquals($expectedResponse, $processedConfiguration);
+    }
+
+    public function testInvalidConfiguration()
+    {
+        $config = [
+            'tags' => ['tag1', 'tag2'],
+            'is_public' => true,
+        ];
+        self::expectException(InvalidConfigurationException::class);
+        (new TableFile())->parse(['config' => $config]);
     }
 }

--- a/tests/Configuration/TableFileTest.php
+++ b/tests/Configuration/TableFileTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Keboola\OutputMapping\Tests\Configuration;
+
+use Keboola\OutputMapping\Configuration\TableFile;
+
+class TableFileTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testConfiguration()
+    {
+        $config = [
+            'tags' => ['tag1', 'tag2'],
+        ];
+        $expectedResponse = [
+            'is_permanent' => true,
+            'tags' => ['tag1', 'tag2'],
+        ];
+        $processedConfiguration = (new TableFile())->parse(['config' => $config]);
+        $this->assertEquals($expectedResponse, $processedConfiguration);
+    }
+}

--- a/tests/Configuration/TableTest.php
+++ b/tests/Configuration/TableTest.php
@@ -26,7 +26,6 @@ class TableTest extends \PHPUnit_Framework_TestCase
             'enclosure' => '"',
             'metadata' => [],
             'column_metadata' => [],
-            'file_tags' => [],
         ];
 
         $processedConfiguration = (new Table())->parse(['config' => $config]);
@@ -49,7 +48,6 @@ class TableTest extends \PHPUnit_Framework_TestCase
             'enclosure' => '\'',
             'metadata' => [],
             'column_metadata' => [],
-            'file_tags' => [],
         ];
 
         $expectedArray = $config;
@@ -102,7 +100,6 @@ class TableTest extends \PHPUnit_Framework_TestCase
             'enclosure' => '"',
             'metadata' => [],
             'column_metadata' => [],
-            'file_tags' => [],
         ];
         $processedConfiguration = (new Table())->parse(['config' => $config]);
         $this->assertEquals($expectedArray, $processedConfiguration);
@@ -129,35 +126,6 @@ class TableTest extends \PHPUnit_Framework_TestCase
             'enclosure' => '"',
             'metadata' => [],
             'column_metadata' => [],
-            'file_tags' => [],
-        ];
-
-        $processedConfiguration = (new Table())->parse(['config' => $config]);
-        $this->assertEquals($expectedArray, $processedConfiguration);
-    }
-
-    public function testFileTags()
-    {
-        $config = [
-            'source' => 'data.csv',
-            'destination' => 'in.c-main.test',
-            'file_tags' => ['test', 'foo'],
-        ];
-
-        $expectedArray = [
-            'source' => 'data.csv',
-            'destination' => 'in.c-main.test',
-            'primary_key' => [],
-            'distribution_key' => [],
-            'columns' => [],
-            'incremental' => false,
-            'delete_where_values' => [],
-            'delete_where_operator' => 'eq',
-            'delimiter' => ',',
-            'enclosure' => '"',
-            'metadata' => [],
-            'column_metadata' => [],
-            'file_tags' => ['test', 'foo'],
         ];
 
         $processedConfiguration = (new Table())->parse(['config' => $config]);

--- a/tests/Writer/StorageApiWriterTest.php
+++ b/tests/Writer/StorageApiWriterTest.php
@@ -1541,7 +1541,6 @@ class StorageApiWriterTest extends BaseWriterTest
         $this->assertNotNull($file);
         $this->assertEquals(4, $file['sizeBytes']);
         $this->assertEquals(sort($expectedTags), sort($file['tags']));
-        $this->assertTrue($file['isPublic']);
         $this->assertNull($file['maxAgeDays']);
     }
 }

--- a/tests/Writer/StorageApiWriterTest.php
+++ b/tests/Writer/StorageApiWriterTest.php
@@ -1510,7 +1510,6 @@ class StorageApiWriterTest extends BaseWriterTest
         $tableFiles = [
             'tags' => ['output-mapping-test', 'another-tag'],
             'is_permanent' => true,
-            'is_public' => true,
         ];
 
         $writer = new FileWriter($this->getStagingFactory());


### PR DESCRIPTION
Doing it this way (parsing the `$tableFiles` as a manifest) allows the parsing and validation to be covered automatically.

So it just needs the two tests, valid/invalid imho