### PR TITLE
fix(output-mapping): preserve production table typing in branches

### DIFF
--- a/src/LoadTableTaskCreator.php
+++ b/src/LoadTableTaskCreator.php
@@ -40,11 +40,14 @@ class LoadTableTaskCreator
             $settings->hasNewNativeTypesFeature(),
             $settings->getTreatValuesAsNull(),
         );
+        $defaultBranchTable = $storageSources->getDefaultBranchTable();
+        $canCreateTypedTable = $defaultBranchTable === null || $defaultBranchTable->isTyped();
 
         // some scenarios are not supported by the SAPI, so we need to take care of them manually here
         // - columns in config + headless CSV (SAPI always expect to have a header in CSV)
         // - sliced files
-        if ($settings->hasNativeTypesFeature() &&
+        if ($canCreateTypedTable &&
+            $settings->hasNativeTypesFeature() &&
             !$storageSources->didTableExistBefore() &&
             $source->hasColumns() && $source->hasColumnMetadata()
         ) {
@@ -67,7 +70,8 @@ class LoadTableTaskCreator
             );
             $this->tableCreator->createTableDefinition($source->getDestination()->getBucketId(), $tableDefinition);
             $loadTask = new LoadTableTask($source->getDestination(), $loadOptions, true);
-        } elseif ($settings->hasNewNativeTypesFeature() &&
+        } elseif ($canCreateTypedTable &&
+            $settings->hasNewNativeTypesFeature() &&
             !$storageSources->didTableExistBefore() &&
             $source->getSchema()
         ) {

--- a/src/Mapping/MappingStorageSources.php
+++ b/src/Mapping/MappingStorageSources.php
@@ -9,8 +9,11 @@ use Keboola\OutputMapping\Storage\TableInfo;
 
 class MappingStorageSources
 {
-    public function __construct(readonly private BucketInfo $bucket, readonly private ?TableInfo $table)
-    {
+    public function __construct(
+        readonly private BucketInfo $bucket,
+        readonly private ?TableInfo $table,
+        readonly private ?TableInfo $defaultBranchTable = null,
+    ) {
     }
 
     public function getBucket(): BucketInfo
@@ -26,5 +29,10 @@ class MappingStorageSources
     public function getTable(): ?TableInfo
     {
         return $this->table;
+    }
+
+    public function getDefaultBranchTable(): ?TableInfo
+    {
+        return $this->defaultBranchTable;
     }
 }

--- a/src/Storage/StoragePreparer.php
+++ b/src/Storage/StoragePreparer.php
@@ -35,6 +35,15 @@ class StoragePreparer
         $destinationTableInfo = $this->getDestinationTableInfoIfExists(
             $processedSource->getDestination()->getTableId(),
         );
+        $defaultBranchTableInfo = null;
+        if ($destinationTableInfo === null &&
+            $this->clientWrapper->getClientOptionsReadOnly()->useBranchStorage() &&
+            $this->clientWrapper->isDevelopmentBranch()
+        ) {
+            $defaultBranchTableInfo = $this->getDefaultBranchTableInfoIfExists(
+                $processedSource->getDestination()->getTableId(),
+            );
+        }
 
         if ($destinationTableInfo !== null) {
             if ($this->hasNewNativeTypeFeature && $processedSource->getSchema()) {
@@ -69,13 +78,26 @@ class StoragePreparer
             );
         }
 
-        return new MappingStorageSources($destinationBucket, $destinationTableInfo);
+        return new MappingStorageSources($destinationBucket, $destinationTableInfo, $defaultBranchTableInfo);
     }
 
     private function getDestinationTableInfoIfExists(string $tableId): ?TableInfo
     {
         try {
             return new TableInfo($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId));
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+
+        return null;
+    }
+
+    private function getDefaultBranchTableInfoIfExists(string $tableId): ?TableInfo
+    {
+        try {
+            return new TableInfo($this->clientWrapper->getClientForDefaultBranch()->getTable($tableId));
         } catch (ClientException $e) {
             if ($e->getCode() !== 404) {
                 throw $e;

--- a/tests/Mapping/MappingStorageSourcesTest.php
+++ b/tests/Mapping/MappingStorageSourcesTest.php
@@ -38,5 +38,10 @@ class MappingStorageSourcesTest extends TestCase
         self::assertEquals($bucketInfo, $source->getBucket());
         self::assertFalse($source->didTableExistBefore());
         self::assertNull($source->getTable());
+        self::assertNull($source->getDefaultBranchTable());
+
+        $source = new MappingStorageSources($bucketInfo, null, $table);
+        self::assertFalse($source->didTableExistBefore());
+        self::assertEquals($table, $source->getDefaultBranchTable());
     }
 }

--- a/tests/Writer/StorageApiLocalTableWriterTest.php
+++ b/tests/Writer/StorageApiLocalTableWriterTest.php
@@ -320,6 +320,85 @@ class StorageApiLocalTableWriterTest extends AbstractTestCase
     }
 
     #[NeedsEmptyOutputBucket]
+    #[NeedsDevBranch]
+    public function testFirstDevBranchWritePreservesNonTypedProductionTable(): void
+    {
+        $root = $this->temp->getTmpFolder();
+        $tableName = 'table';
+        $tableId = $this->emptyOutputBucketId . '.' . $tableName;
+        $productionCsv = new CsvFile($root . '/production.csv');
+        $productionCsv->writeRow(['Id', 'Name']);
+        $productionCsv->writeRow(['1', 'production']);
+
+        $this->clientWrapper->getTableAndFileStorageClient()->createTableAsync(
+            $this->emptyOutputBucketId,
+            $tableName,
+            $productionCsv,
+        );
+        self::assertFalse($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+
+        $clientOptions = $this->clientWrapper->getClientOptionsReadOnly()
+            ->setBranchId($this->devBranchId)
+            ->setUseBranchStorage(true)
+        ;
+        $this->clientWrapper = new ClientWrapper($clientOptions);
+
+        file_put_contents(
+            $root . '/upload/table.csv',
+            "\"2\",\"development\"\n",
+        );
+
+        $realToken = $this->clientWrapper->getToken();
+        $token = $this->createMock(StorageApiToken::class);
+        $token
+            ->method('hasFeature')
+            ->willReturnCallback(
+                static fn(string $feature): bool => $feature === OutputMappingSettings::NEW_NATIVE_TYPES_FEATURE
+                    || $realToken->hasFeature($feature),
+            )
+        ;
+
+        $tableQueue = $this->getTableLoader()->uploadTables(
+            configuration: new OutputMappingSettings(
+                configuration: [
+                    'mapping' => [
+                        [
+                            'source' => 'table.csv',
+                            'destination' => $tableId,
+                            'schema' => [
+                                [
+                                    'name' => 'Id',
+                                    'data_type' => [
+                                        'base' => [
+                                            'type' => 'INTEGER',
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'name' => 'Name',
+                                    'data_type' => [
+                                        'base' => [
+                                            'type' => 'STRING',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                sourcePathPrefix: 'upload',
+                storageApiToken: $token,
+                isFailedJob: false,
+                dataTypeSupport: OutputMappingSettings::DATA_TYPES_SUPPORT_AUTHORITATIVE,
+            ),
+            systemMetadata: new SystemMetadata(['componentId' => 'foo', 'branchId' => $this->devBranchId]),
+        );
+        $tableQueue->waitForAll();
+
+        self::assertFalse($this->clientWrapper->getTableAndFileStorageClient()->getTable($tableId)['isTyped']);
+    }
+
+    #[NeedsEmptyOutputBucket]
     public function testWriteTableOutputMappingExistingTable(): void
     {
         $root = $this->temp->getTmpFolder();


### PR DESCRIPTION
## Summary
Fixes SUPPORT-16987 by consulting the corresponding default-branch table when a destination is being created for the first time in Branched Storage.

`LoadTableTaskCreator` now applies automatic typed-table creation only when no production table exists or the production table is already typed. A production non-typed table therefore remains non-typed in the development branch even when the output contains an authoritative schema.

Adds an integration regression that creates a non-typed production table, performs its first schema-enabled write in a real development branch, and verifies the branch table remains non-typed.

## Release Notes
**Justification, description**

Preserve an existing production table's non-typed status during its first output-mapping write in Branched Storage.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Limited to first creation of a development-branch destination whose table already exists in the default branch. New branch-only tables and existing branch tables retain their current behavior.

**Deployment Plan**

Release the output-mapping library and consume it through the normal dependency update process.

**Rollback Plan**

Revert the library release/dependency update.

**Post-Release Support Plan**

Monitor branch output-mapping jobs and confirm the SUPPORT-16987 reproduction remains non-typed.

Link to Devin session: https://app.devin.ai/sessions/fe301b5a5eed4f07ae71675da2744aac
Requested by: @terezaskalova